### PR TITLE
add SpoutTexture type for easily receiving and rendering anywhere

### DIFF
--- a/SpoutTexture.gd
+++ b/SpoutTexture.gd
@@ -1,0 +1,66 @@
+extends ImageTexture
+class_name SpoutTexture
+
+@export var sender_name: String : set = _set_sender_name
+
+var spout: Spout
+
+# receiving image buffer
+var image: Image
+
+func _init():
+    spout = Spout.new()
+    image = Image.create(
+        100, 100, # placeholder buffer until we get a real image to show off
+        false,
+        Image.FORMAT_RGBA8
+    )
+    set_image(image)
+    
+    # makes sure to update the data from the spout source
+    # while the texture is visible anywhere
+    RenderingServer.texture_set_force_redraw_if_visible(get_rid(), true)
+    RenderingServer.frame_pre_draw.connect(_update)
+
+func _set_sender_name(name):
+    sender_name = name
+    
+    # in case a connection was already open
+    spout.release_receiver()
+    
+    # connect to new receiver
+    spout.set_receiver_name(name)
+    
+func _rebuild_image():
+    if spout.get_sender_width() <= 0 || spout.get_sender_height() <= 0:
+        return
+    
+    image = Image.create(
+        spout.get_sender_width(), spout.get_sender_height(),
+        false,
+        Image.FORMAT_RGBA8
+    )
+    set_image(image)
+    
+func _notification(what):
+    if what == NOTIFICATION_PREDELETE:
+        # in case a connection was already open
+        if spout != null:
+            spout.release_receiver()
+        
+func _update():
+    if is_queued_for_deletion():
+        return
+    
+    var active_name = spout.get_sender_name()
+    if active_name != sender_name:
+        _set_sender_name(sender_name)
+        return
+    
+    # detect if source info has changed
+    # Spout SDK states that this is required before every receive call
+    if spout.is_updated():
+        _rebuild_image()
+    
+    if spout.receive_image(image, Spout.FORMAT_RGBA):
+        update(image)


### PR DESCRIPTION
Implements a new Texture2D type hooked into a Spout receiver.  This makes it easy to use it anywhere you can use a texture, such as materials on 3D objects or within TextureRects in UIs.

Unfortunately due to some limitations with the cpp bindings, I couldn't make an equivalent version to compile with the library, so for now it's included as a complementary GDScript class.  These limitations should be resolved in the 4.2 release of Godot and the accompanying cpp bindings, but since that has not yet reached stable release I opted to avoid including it for now.  I will open a follow-up PR for that once 4.2 stable is generally available.

Additionally, Godot's has limitations that prevent rendering the texture live within the editor.  However, it works fine within a running scene.