### PR TITLE
Fixing issues with godot 4.4

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -13,9 +13,9 @@ void initialize_spout_gd_module(ModuleInitializationLevel p_level) {
         return;
     }
 
-    godot::ClassDB::register_class<Spout>();
-    godot::ClassDB::register_class<SpoutTexture>();
-    godot::ClassDB::register_class<SpoutViewport>();
+    GDREGISTER_CLASS(Spout);
+    GDREGISTER_CLASS(SpoutTexture);
+    GDREGISTER_CLASS(SpoutViewport);
 }
 
 void uninitialize_spout_gd_module(ModuleInitializationLevel p_level) {

--- a/src/spout_texture.cpp
+++ b/src/spout_texture.cpp
@@ -83,7 +83,7 @@ void SpoutTexture::poll_server() {
 
 SpoutTexture::SpoutTexture() {
     // create a placeholder image for spout
-    _spout = new Spout();
+    _spout = memnew(Spout);
     _sender_name = String("");
     _update_in_editor = false;
     rebuild_image(1, 1);


### PR DESCRIPTION
Didn't found alot of documentation about it. But it seems to be the preferd way to use `memnew` cause if calls some callbacks that are needed. 4.2 was less stict but 4.4 needs it see also: https://forum.godotengine.org/t/godot-4-3-gdextension-is-more-strict-about-wrapping-godot-objects-than-4-2/83758/6