### PR TITLE
remove duplicate get_image() call

### DIFF
--- a/src/spout_viewport.cpp
+++ b/src/spout_viewport.cpp
@@ -31,7 +31,7 @@ void SpoutViewport::poll_server() {
     auto image = get_texture()->get_image();
     image->clear_mipmaps();
     _spout->send_image(
-        get_texture()->get_image(),
+        image,
         image->get_width(),
         image->get_height(),
         has_transparent_background() ? Spout::GLFormat::FORMAT_RGBA : Spout::GLFormat::FORMAT_RGB,


### PR DESCRIPTION
according to the docs, this is an expensive call:
> Returns an [Image](https://docs.godotengine.org/en/stable/classes/class_image.html#class-image) that is a copy of data from this Texture2D (a new [Image](https://docs.godotengine.org/en/stable/classes/class_image.html#class-image) is created each time). [Image](https://docs.godotengine.org/en/stable/classes/class_image.html#class-image)s can be accessed and manipulated directly.

> Note: This will fetch the texture data from the GPU, which might cause performance problems when overused. Avoid calling [get_image()](https://docs.godotengine.org/en/stable/classes/class_texture2d.html#class-texture2d-method-get-image) every frame, especially on large textures.

https://docs.godotengine.org/en/stable/classes/class_texture2d.html#class-texture2d-method-get-image

this is still far from a perfect solution, but getting rid of the duplicated call increased my performance significantly when sending a single 1080p texture