### PR TITLE
use Ref instead of raw pointers

### DIFF
--- a/src/spout_gd.cpp
+++ b/src/spout_gd.cpp
@@ -203,5 +203,8 @@ Spout::Spout() {
 }
 
 Spout::~Spout() {
-    lib->Release();
+    if (lib != nullptr) {
+        lib->Release();
+        lib = nullptr;
+    }
 }

--- a/src/spout_gd.h
+++ b/src/spout_gd.h
@@ -13,7 +13,7 @@ class Spout : public RefCounted {
     GDCLASS(Spout, RefCounted);
 
    private:
-    SPOUTLIBRARY *lib;
+    SPOUTLIBRARY *lib{nullptr};
 
    protected:
     static void _bind_methods();

--- a/src/spout_texture.cpp
+++ b/src/spout_texture.cpp
@@ -83,7 +83,7 @@ void SpoutTexture::poll_server() {
 
 SpoutTexture::SpoutTexture() {
     // create a placeholder image for spout
-    _spout = memnew(Spout);
+    _spout = Ref(memnew(Spout));
     _sender_name = String("");
     _update_in_editor = false;
     rebuild_image(1, 1);
@@ -99,7 +99,7 @@ SpoutTexture::SpoutTexture() {
 }
 
 SpoutTexture::~SpoutTexture() {
-    if (_spout != NULL) {
+    if (_spout != nullptr) {
         _spout->release_receiver();
     }
 }

--- a/src/spout_texture.h
+++ b/src/spout_texture.h
@@ -19,7 +19,7 @@ class SpoutTexture : public ImageTexture {
     GDCLASS(SpoutTexture, ImageTexture);
 
     private:
-        Spout *_spout;
+        Ref<Spout> _spout;
         Ref<Image> _image;
         PackedByteArray _buffer;
         String _sender_name;

--- a/src/spout_viewport.cpp
+++ b/src/spout_viewport.cpp
@@ -41,7 +41,7 @@ void SpoutViewport::poll_server() {
 
 void SpoutViewport::_notification(int p_what) {
     if (p_what == NOTIFICATION_READY && !Engine::get_singleton()->is_editor_hint()) {
-        _spout = new Spout();
+        _spout = Ref(memnew(Spout));
 
         auto _update = callable_mp(this, &SpoutViewport::poll_server);
 
@@ -51,7 +51,7 @@ void SpoutViewport::_notification(int p_what) {
         );
     }
     else if (p_what == NOTIFICATION_PREDELETE) {
-        if (_spout != NULL) {
+        if (_spout != nullptr) {
             _spout->release_sender();
         }    
     }
@@ -59,12 +59,11 @@ void SpoutViewport::_notification(int p_what) {
 
 SpoutViewport::SpoutViewport() {
     // create a placeholder image for spout
-    _spout = NULL;
     _sender_name = String("");   
 }
 
 SpoutViewport::~SpoutViewport() {
-    if (_spout != NULL) {
+    if (_spout != nullptr) {
         _spout->release_sender();
     }
 }

--- a/src/spout_viewport.h
+++ b/src/spout_viewport.h
@@ -21,7 +21,7 @@ class SpoutViewport : public SubViewport {
     GDCLASS(SpoutViewport, SubViewport);
 
     private:
-        Spout *_spout;
+        Ref<Spout> _spout;
         String _sender_name;
 
         void poll_server();


### PR DESCRIPTION
this fixes a memory leak in SpoutViewport and SpoutTexture. Since `Spout` is a ref-counted class, we need to hold it in a `Ref` object for it to properly get freed