### PR TITLE
add worker thread to SpoutViewport

### DIFF
--- a/src/spout_gd.cpp
+++ b/src/spout_gd.cpp
@@ -27,6 +27,11 @@ bool Spout::send_image(const Ref<Image> p_image, unsigned int p_width, unsigned 
     return lib->SendImage(p, p_width, p_height, p_gl_format, p_invert);
 }
 
+bool Spout::send_bytes(const PackedByteArray& bytes, unsigned int p_width, unsigned int p_height, GLFormat p_gl_format, bool p_invert) {
+    const unsigned char *p = (const unsigned char *)bytes.ptr();
+    return lib->SendImage(p, p_width, p_height, p_gl_format, p_invert);
+}
+
 String Spout::get_name() {
     return String(lib->GetName());
 }
@@ -163,6 +168,7 @@ void Spout::_bind_methods() {
     ClassDB::bind_method(D_METHOD("send_fbo", "fbo_id", "width", "height", "invert"), &Spout::send_fbo, DEFVAL(true));
     ClassDB::bind_method(D_METHOD("send_texture", "texture_id", "texture_target", "width", "height", "invert", "host_fbo"), &Spout::send_texture, DEFVAL(true), DEFVAL(0));
     ClassDB::bind_method(D_METHOD("send_image", "image", "width", "height", "gl_format", "invert"), &Spout::send_image, DEFVAL(Spout::FORMAT_RGBA), DEFVAL(true));
+    ClassDB::bind_method(D_METHOD("send_bytes", "bytes", "width", "height", "gl_format", "invert"), &Spout::send_bytes, DEFVAL(Spout::FORMAT_RGBA), DEFVAL(true));
     ClassDB::bind_method(D_METHOD("get_name"), &Spout::get_name);
     ClassDB::bind_method(D_METHOD("get_width"), &Spout::get_width);
     ClassDB::bind_method(D_METHOD("get_height"), &Spout::get_height);

--- a/src/spout_gd.h
+++ b/src/spout_gd.h
@@ -45,6 +45,7 @@ class Spout : public RefCounted {
     bool send_fbo(GLuint p_fbo_id, unsigned int p_width, unsigned int p_height, bool p_invert = true);
     bool send_texture(GLuint p_texture_id, GLuint p_texture_target, unsigned int p_width, unsigned int p_height, bool p_invert = true, GLuint p_host_fbo = 0);
     bool send_image(const Ref<Image> p_image, unsigned int p_width, unsigned int p_height, GLFormat p_gl_format = GLFormat::FORMAT_RGBA, bool p_invert = false);
+    bool send_bytes(const PackedByteArray& bytes, unsigned int p_width, unsigned int p_height, GLFormat p_gl_format = GLFormat::FORMAT_RGBA, bool p_invert = false);
     String get_name();
     unsigned int get_width();
     unsigned int get_height();

--- a/src/spout_viewport.h
+++ b/src/spout_viewport.h
@@ -13,6 +13,10 @@
 #include <godot_cpp/variant/variant.hpp>
 #include <godot_cpp/variant/rid.hpp>
 
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
 #include "spout_gd.h"
 
 using namespace godot;
@@ -24,7 +28,17 @@ class SpoutViewport : public SubViewport {
         Ref<Spout> _spout;
         String _sender_name;
 
+        godot::Vector2i _size;
+        PackedByteArray _buffer;
+
+        std::thread _spout_thread;
+        std::condition_variable _spout_signal;
+        std::mutex _buffer_mutex;
+        std::atomic<bool> _new_frame_ready{false};
+        bool _stop_worker = false;
+
         void poll_server();
+        void start_worker_thread();
     protected:
         static void _bind_methods();
         void _notification(int p_what);


### PR DESCRIPTION
I made some observations in https://github.com/you-win/spout-gd/issues/23 that led to these changes:
1. `spout->SendImage()` is quite slow (~around 10ms for me with a 1080p texture)
2. `get_texture()->get_image()` is also quite slow (this is noted [here in the docs](https://docs.godotengine.org/en/stable/classes/class_texture2d.html#class-texture2d-method-get-image))

this PR does 2 things:
- we avoid the conversion to a `godot::Image` by accessing the bytes from the rendering device directly
- we copy those bytes to a secondary buffer, and perform the slow operation (`SendImage()`) on its own thread

these 2 changes brought my project from ~60 to 120+ fps with a single 1080p `SpoutViewport` instance (Forward+ / Vulkan / godot 4.4).

I have **not** tested this thoroughly with all the renderers yet; I wouldn't be opposed to putting this functionality behind a "Use Thread" checkbox in the inspector, but I'll leave that judgement to you